### PR TITLE
Blossom network upgrade

### DIFF
--- a/src/Lykke.Service.Zcash.SignService.Core/Services/ITransactionService.cs
+++ b/src/Lykke.Service.Zcash.SignService.Core/Services/ITransactionService.cs
@@ -6,7 +6,7 @@ namespace Lykke.Service.Zcash.SignService.Core.Services
 {
     public interface ITransactionService
     {
-        Task<string> SignAsync(string tx, Utxo[] outputs, string[] keys);
+        Task<string> SignAsync(string tx, Utxo[] outputs, string[] keys, uint? branchId = null);
         Task<bool> ValidateNotSignedTransactionAsync(string tx);
     }
 }

--- a/src/Lykke.Service.Zcash.SignService.Services/TransactionService.cs
+++ b/src/Lykke.Service.Zcash.SignService.Services/TransactionService.cs
@@ -24,11 +24,11 @@ namespace Lykke.Service.Zcash.SignService.Services
             _isLocal = _blockchainReader == null;
         }
 
-        public async Task<string> SignAsync(string tx, Utxo[] outputs, string[] keys)
+        public async Task<string> SignAsync(string tx, Utxo[] outputs, string[] keys, uint? branchId = null)
         {
             if (_isLocal)
             {
-                return SignLocally(tx, outputs, keys);
+                return SignLocally(tx, outputs, keys, branchId);
             }
             else
             {
@@ -60,9 +60,9 @@ namespace Lykke.Service.Zcash.SignService.Services
             }
         }
 
-        private string SignLocally(string tx, Utxo[] outputs, string[] keys)
+        private string SignLocally(string tx, Utxo[] outputs, string[] keys, uint? branchId)
         {
-            var transaction = new ZcashTransaction(tx);
+            var transaction = new ZcashTransaction(tx, branchId);
             var privateKeys = keys.Select(k => Key.Parse(k)).ToArray();
             var coins = outputs
                 .Select(x => new Coin(uint256.Parse(x.TxId), x.Vout, Money.Coins(x.Amount), new Script(Encoders.Hex.DecodeData(x.ScriptPubKey))))

--- a/src/Lykke.Service.Zcash.SignService/Controllers/SignController.cs
+++ b/src/Lykke.Service.Zcash.SignService/Controllers/SignController.cs
@@ -23,12 +23,12 @@ namespace Lykke.Service.Zcash.SignService.Controllers
         public async Task<IActionResult> SignTransaction([FromBody]SignTransactionRequest signRequest)
         {
             if (!ModelState.IsValid ||
-                !ModelState.IsValidRequest(signRequest, _transactionService, out var tx, out var spentOutputs))
+                !ModelState.IsValidRequest(signRequest, _transactionService, out var tx, out var spentOutputs, out var branchId))
             {
                 return BadRequest(ErrorResponse.Create(ModelState));
             }
 
-            var signed = await _transactionService.SignAsync(tx, spentOutputs, signRequest.PrivateKeys);
+            var signed = await _transactionService.SignAsync(tx, spentOutputs, signRequest.PrivateKeys, branchId);
 
             return Ok(new SignTransactionResponse()
             {

--- a/src/Lykke.Service.Zcash.SignService/Helpers/ModelStateExtensions.cs
+++ b/src/Lykke.Service.Zcash.SignService/Helpers/ModelStateExtensions.cs
@@ -13,10 +13,12 @@ namespace Lykke.Service.Zcash.SignService.Helpers
             SignTransactionRequest request,
             ITransactionService transactionService,
             out string tx,
-            out Utxo[] spentOutputs)
+            out Utxo[] spentOutputs,
+            out uint? branchId)
         {
             tx = null;
             spentOutputs = null;
+            branchId = null;
 
             if (!self.IsValid)
             {
@@ -25,7 +27,7 @@ namespace Lykke.Service.Zcash.SignService.Helpers
 
             try
             {
-                (tx, spentOutputs) = JsonConvert.DeserializeObject<(string, Utxo[])>(request.TransactionContext.Base64ToString());
+                (tx, spentOutputs, branchId) = JsonConvert.DeserializeObject<(string, Utxo[], uint?)>(request.TransactionContext.Base64ToString());
             }
             catch
             {


### PR DESCRIPTION
Branch ID has been changed for Blossom, see https://zcash.readthedocs.io/en/latest/rtd_pages/nu_dev_guide.html#blossom. Branch ID is used in signature algorithm, but transaction format or version have not been changed so we have to route it to the sign service from API.